### PR TITLE
Add 'text-align-last: left;' to staticscroll.css

### DIFF
--- a/staticscroll.css
+++ b/staticscroll.css
@@ -18,6 +18,7 @@
 	background: white;
 	line-height: 1.5!important;
 	text-align: justify;
+	text-align-last: left;
 	color: #000022;
 	background-color: #f8f8f8;
 	margin-top: 30px!important;


### PR DESCRIPTION
It helps with readability for paragraphs other than the :last-child to be aligned left rather than being

```
stretched              across              the              entire              screen.
```
